### PR TITLE
refactor: consolidate postcss config

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,0 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
-};
-
-export default config;


### PR DESCRIPTION
## Summary
- drop duplicate PostCSS config
- use a CommonJS PostCSS config with Tailwind plugin

## Testing
- `pnpm build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68991a826ba8832c86101e4accbcca36